### PR TITLE
Make test more reliable by setting higher timeout

### DIFF
--- a/amazon-lex-connector-test/src_test/com/axonivy/connector/amazon/lex/test/ChatBotIT.java
+++ b/amazon-lex-connector-test/src_test/com/axonivy/connector/amazon/lex/test/ChatBotIT.java
@@ -4,6 +4,8 @@ import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.open;
 
+import java.time.Duration;
+
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -43,7 +45,7 @@ public class ChatBotIT {
 
   private void sendInputAndWait(String input) {
     var chatSize = sendInput(input);
-    $(By.id("form:chat")).shouldHave(childrenSize(chatSize+2));
+    $(By.id("form:chat")).shouldHave(childrenSize(chatSize+2), Duration.ofSeconds(10));
   }
 
   private int sendInput(String input) {


### PR DESCRIPTION
Seems I was not able to pull the latest version successfully. However, it was already converted to project version 10. 
This PR simply makes the test more stable. It waits now 10 seconds for an answer from the Amazon LEX bot. It seems it answers a little bit slow if you don't use them often.